### PR TITLE
build: bump: resolver: lts-20.26

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-20.19
+resolver: lts-20.26
 extra-deps:
   - text-icu-translit-0.1.0.7@sha256:c8eaaee3331417a250365474067b7cb0f196ebabd04b3fe834c4e2b5a212b5ce,1723

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -13,7 +13,7 @@ packages:
     hackage: text-icu-translit-0.1.0.7@sha256:c8eaaee3331417a250365474067b7cb0f196ebabd04b3fe834c4e2b5a212b5ce,1723
 snapshots:
 - completed:
-    sha256: 42f77c84b34f68c30c2cd0bf8c349f617a0f428264362426290847a6a2019b64
-    size: 649618
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/19.yaml
-  original: lts-20.19
+    sha256: 5a59b2a405b3aba3c00188453be172b85893cab8ebc352b1ef58b0eae5d248a2
+    size: 650475
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/26.yaml
+  original: lts-20.26


### PR DESCRIPTION
HLSのサポート範囲の変動に追随。
text-icu-translitの互換性の問題から最新版には上げられない。
解決するPRは出したけれど音沙汰がないので捨てるべき日が来たのかもしれない。